### PR TITLE
Suggestions

### DIFF
--- a/helloworld/asm/main.s
+++ b/helloworld/asm/main.s
@@ -1,10 +1,9 @@
-	.text
-	.globl	entrypoint
+.globl entrypoint
 entrypoint:
 	lddw r1, .message
 	mov64 r2, 12
 	call sol_log_
 	exit
-	.section	.rodata
-.message:
-	.asciz	"Hello world!"
+.extern sol_log_
+.rodata 
+	.message: .ascii "Hello world!"

--- a/helloworld/asm/main.s
+++ b/helloworld/asm/main.s
@@ -4,6 +4,5 @@ entrypoint:
 	mov64 r2, 12
 	call sol_log_
 	exit
-.extern sol_log_
 .rodata 
 	message: .ascii "Hello world!"

--- a/helloworld/asm/main.s
+++ b/helloworld/asm/main.s
@@ -6,4 +6,4 @@ entrypoint:
 	exit
 .extern sol_log_
 .rodata 
-	.message: .ascii "Hello world!"
+	message: .ascii "Hello world!"


### PR DESCRIPTION
Made a few changes, let me know what you think!

1. removed unnecessary section names (ie: only include what the linker requires to build it)
2. replaced `.asciz` with `.ascii` as, according to the [Assembly Directives](https://ftp.gnu.org/old-gnu/Manuals/gas-2.9.1/html_chapter/as_7.html#SEC73) documentation, .asciz seems to add an additional zero byte to the binary we don't particularly need.