### PR TITLE
perf: change optimize level ReleaseSmall -> ReleaseFast for zig's programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,11 @@ lets the VM assume it worked.
 | Language | CU Usage |
 | --- | --- |
 | Rust | 464 |
-| Zig | 469 |
+| Zig | 186 |
 | C | 103 |
 | Assembly | 23 |
 
 This one starts to get interesting since it requires parsing the instruction
 input. Since the assembly version knows exactly where to find everything, it can
 be hyper-optimized. The C version is also very performant.
+Zig's version should perform the same as C, but there are some inefficiencies that are currently fixing.

--- a/helloworld/zig/build.zig
+++ b/helloworld/zig/build.zig
@@ -4,7 +4,7 @@ const base58 = @import("base58");
 
 pub fn build(b: *std.Build) !void {
     const target = b.resolveTargetQuery(solana.sbf_target);
-    const optimize = .ReleaseSmall;
+    const optimize = .ReleaseFast;
     const program = b.addSharedLibrary(.{
         .name = "solana_program_rosetta_helloworld",
         .root_source_file = b.path("main.zig"),

--- a/transfer-lamports/zig/build.zig
+++ b/transfer-lamports/zig/build.zig
@@ -4,7 +4,7 @@ const base58 = @import("base58");
 
 pub fn build(b: *std.Build) !void {
     const target = b.resolveTargetQuery(solana.sbf_target);
-    const optimize = .ReleaseSmall;
+    const optimize = .ReleaseFast;
     const program = b.addSharedLibrary(.{
         .name = "solana_program_rosetta_transfer_lamports",
         .root_source_file = b.path("main.zig"),


### PR DESCRIPTION
There are a lot of inefficiencies in the current version of `zig-sdk` that are fixing right now.
I believe, the proper realization of `zig-sdk` should behave ~ the same as a `C` one.

In this MR I just changed the optimization level (debug asserts were stripped out under the hood) and "win" CU consumption in **~2.5 times**