### PR TITLE
transfer-lamports: Remove one instruction from ASM

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ lets the VM assume it worked.
 | Rust | 464 |
 | Zig | 186 |
 | C | 103 |
-| Assembly | 23 |
+| Assembly | 22 |
 
 This one starts to get interesting since it requires parsing the instruction
 input. Since the assembly version knows exactly where to find everything, it can

--- a/transfer-lamports/asm/main.s
+++ b/transfer-lamports/asm/main.s
@@ -1,4 +1,3 @@
-	.text
 	.globl	entrypoint
 entrypoint:
 	ldxdw r2, [r1 + 0] # get number of accounts
@@ -8,14 +7,13 @@ entrypoint:
 	ldxdw r2, [r1 + 8 + 8 + 32 + 32] # get source lamports
 	ldxdw r3, [r1 + 8 + 8 + 32 + 32 + 8] # get account data size
 	mov64 r4, r1
-	add64 r4, 8 + 8 + 32 + 32 + 8 + 8 + 10240 # calculate end of account data
+	add64 r4, 8 + 8 + 32 + 32 + 8 + 8 + 10240 + 8 # calculate end of account data
 	add64 r4, r3
 	mov64 r5, r4 # check how much padding we need to add
 	and64 r5, 7 # clear high bits
 	jeq r5, 0, 1 # no low bits set, jump ahead
 	add64 r4, 8 # add 8 for truncation if needed
 	and64 r4, -8 # clear low bits
-	add64 r4, 8 # rent epoch
 	ldxb r5, [r4 + 0] # get second account
 	jne r5, 0xff, error # we don't allow duplicates
 	ldxdw r5, [r4 + 8 + 32 + 32] # get destination lamports


### PR DESCRIPTION
#### Problem

There's one additional addition in the transfer-lamports assembly implementation that isn't required.

#### Summary of changes

Remove it, and at the same time, remove the `.text` heading in the file, similar to #1