### PR TITLE
zig: Improve transfer-lamports performance with new SDK version

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ lets the VM assume it worked.
 | Language | CU Usage |
 | --- | --- |
 | Rust | 464 |
-| Zig | 186 |
+| Zig | 42 |
 | C | 103 |
 | Assembly | 22 |
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ lets the VM assume it worked.
 | Language | CU Usage |
 | --- | --- |
 | Rust | 464 |
-| Zig | 42 |
+| Zig | 43 |
 | C | 103 |
 | Assembly | 22 |
 

--- a/transfer-lamports/zig/build.zig.zon
+++ b/transfer-lamports/zig/build.zig.zon
@@ -20,8 +20,9 @@
             .hash = "1220fd067bf167b9062cc29ccf715ff97643c2d3f8958beea863b6036876bb71bcb8",
         },
         .@"solana-program-sdk" = .{
-            .url = "https://github.com/joncinque/solana-program-sdk-zig/archive/refs/tags/v0.13.1.tar.gz",
-            .hash = "122030336f1257e3c0aa64243f5243f554b903c6b9ef3a91d48bfbe896c0c7d9b13b",
+            .path = "../../../zig/solana-program-sdk-zig",
+            //.url = "https://github.com/joncinque/solana-program-sdk-zig/archive/refs/tags/v0.13.1.tar.gz",
+            //.hash = "122030336f1257e3c0aa64243f5243f554b903c6b9ef3a91d48bfbe896c0c7d9b13b",
         },
     },
 

--- a/transfer-lamports/zig/build.zig.zon
+++ b/transfer-lamports/zig/build.zig.zon
@@ -15,23 +15,11 @@
     // Once all dependencies are fetched, `zig build` no longer requires
     // internet connectivity.
     .dependencies = .{
-        .base58 = .{
-            .url = "https://github.com/joncinque/base58-zig/archive/refs/tags/v0.13.3.tar.gz",
-            .hash = "1220fd067bf167b9062cc29ccf715ff97643c2d3f8958beea863b6036876bb71bcb8",
-        },
         .@"solana-program-sdk" = .{
-            .path = "../../../zig/solana-program-sdk-zig",
-            //.url = "https://github.com/joncinque/solana-program-sdk-zig/archive/refs/tags/v0.13.1.tar.gz",
-            //.hash = "122030336f1257e3c0aa64243f5243f554b903c6b9ef3a91d48bfbe896c0c7d9b13b",
+            .url = "https://github.com/joncinque/solana-program-sdk-zig/archive/refs/tags/v0.14.0.tar.gz",
+            .hash = "1220bdfa4ea1ab6330959ce4bc40feb5b39a7f98923a266a94b69e27fd20c3526786",
         },
     },
-
-    // Specifies the set of files and directories that are included in this package.
-    // Only files and directories listed here are included in the `hash` that
-    // is computed for this package.
-    // Paths are relative to the build root. Use the empty string (`""`) to refer to
-    // the build root itself.
-    // A directory listed here means that all files within, recursively, are included.
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/transfer-lamports/zig/main.zig
+++ b/transfer-lamports/zig/main.zig
@@ -2,13 +2,9 @@ const sol = @import("solana-program-sdk");
 
 export fn entrypoint(input: [*]u8) u64 {
     const context = sol.Context.load(input) catch return 1;
-    const accounts = context.loadRawAccounts(sol.allocator) catch return 1;
-    defer accounts.deinit();
-
-    const source = accounts.items[0];
-    const destination = accounts.items[1];
+    const source = context.accounts[0];
+    const destination = context.accounts[1];
     source.lamports().* -= 5;
     destination.lamports().* += 5;
-
     return 0;
 }


### PR DESCRIPTION
#### Problem

The current Zig implementation of transfer-lamports is pretty inefficient, still using 186 CUs. This is because v0.13 of the SDK uses many allocations for the provided accounts.

#### Summary of changes

v0.14.0 of the SDK removes all allocations in the entrypoint, so update the transfer-lamports program to use it. Reduces CUs from 186 to 43, making it more efficient than C!