### PR TITLE
cpi-zig: Update to newest SDK and SPL libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,5 +180,5 @@ the address and `invoke_signed` to CPI to the system program.
 | Language | CU Usage |
 | --- | --- |
 | Rust | 3662 |
-| Zig | 3141 |
+| Zig | 2825 |
 | C | 3122 |

--- a/cpi/zig/build.zig.zon
+++ b/cpi/zig/build.zig.zon
@@ -15,17 +15,13 @@
     // Once all dependencies are fetched, `zig build` no longer requires
     // internet connectivity.
     .dependencies = .{
-        .base58 = .{
-            .url = "https://github.com/joncinque/base58-zig/archive/refs/tags/v0.13.3.tar.gz",
-            .hash = "1220fd067bf167b9062cc29ccf715ff97643c2d3f8958beea863b6036876bb71bcb8",
-        },
         .@"solana-program-sdk" = .{
-            .url = "https://github.com/joncinque/solana-program-sdk-zig/archive/refs/tags/v0.13.1.tar.gz",
-            .hash = "122030336f1257e3c0aa64243f5243f554b903c6b9ef3a91d48bfbe896c0c7d9b13b",
+            .url = "https://github.com/joncinque/solana-program-sdk-zig/archive/refs/tags/v0.14.0.tar.gz",
+            .hash = "1220bdfa4ea1ab6330959ce4bc40feb5b39a7f98923a266a94b69e27fd20c3526786",
         },
         .@"solana-program-library" = .{
-            .url = "https://github.com/joncinque/solana-program-library-zig/archive/refs/tags/v0.13.1.tar.gz",
-            .hash = "12208555f3e41bfba0ac89c4a7c6884595c78aa5d4ff4f99869c7ae0e396fd762448",
+            .url = "https://github.com/joncinque/solana-program-library-zig/archive/refs/tags/v0.14.0.tar.gz",
+            .hash = "1220b5f9dbfa8e36b67c4bcbddb44d1e74a1c8eda0f10f485c553f4a316994e1a3d5",
         },
     },
 

--- a/cpi/zig/main.zig
+++ b/cpi/zig/main.zig
@@ -6,10 +6,7 @@ const SIZE = 42;
 
 export fn entrypoint(input: [*]u8) u64 {
     const context = sol.Context.load(input) catch return 1;
-    const accounts = context.loadRawAccounts(sol.allocator) catch return 1;
-    defer accounts.deinit();
-
-    const allocated = accounts.items[0];
+    const allocated = context.accounts[0];
 
     const expected_allocated_key = sol.PublicKey.createProgramAddress(
         &.{ "You pass butter", &.{context.data[0]} },
@@ -20,12 +17,11 @@ export fn entrypoint(input: [*]u8) u64 {
     if (!allocated.id().equals(expected_allocated_key)) return 1;
 
     // Invoke the system program to allocate account data
-    system_ix.allocate(
-        sol.allocator,
-        allocated.info(),
-        SIZE,
-        .{ .seeds = &.{&.{ "You pass butter", &.{context.data[0]} }} },
-    ) catch return 1;
+    system_ix.allocate(.{
+        .account = allocated.info(),
+        .space = SIZE,
+        .seeds = &.{&.{ "You pass butter", &.{context.data[0]} }},
+    }) catch return 1;
 
     return 0;
 }


### PR DESCRIPTION
#### Problem

The Zig CPI example uses a few too many compute units due to the overhead from entrypoint and CPI allocations, but the newest SDK and SPL libraries avoid allocations.

#### Summary of changes

Update the dependencies and use them, reducing CUs by over 300.