### PR TITLE
token-zig: Avoid so many pubkey comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Token program.
 | Language | CU Usage |
 | --- | --- |
 | Rust | 1115 |
-| Zig | 165 |
+| Zig | 166 |
 
   * Initialize Account
 
@@ -211,25 +211,25 @@ Token program.
 | Language | CU Usage |
 | --- | --- |
 | Rust | 2189 |
-| Zig | 215 |
+| Zig | 195 |
 
   * Transfer
 
 | Language | CU Usage |
 | --- | --- |
 | Rust | 2208 |
-| Zig | 205 |
+| Zig | 160 |
 
   * Burn
 
 | Language | CU Usage |
 | --- | --- |
 | Rust | 2045 |
-| Zig | 175 |
+| Zig | 157 |
 
   * Close Account
 
 | Language | CU Usage |
 | --- | --- |
 | Rust | 1483 |
-| Zig | 291 |
+| Zig | 260 |


### PR DESCRIPTION
#### Problem

Pubkey comparisons are expensive operations on-chain, but they aren't always required.

#### Summary of changes

Update the Zig Token program to avoid pubkey comparisons, which gives much better performance. Also, update the performance numbers.