### PR TITLE
transfer-lamports: Update zig version for reduced CUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ a little-endian u64 in instruction data.
 | Language | CU Usage |
 | --- | --- |
 | Rust | 459 |
-| Zig | 44 |
+| Zig | 38 |
 | C | 104 |
 | Assembly | 30 |
 | Rust (pinocchio) | 32 |

--- a/transfer-lamports/zig/build.zig.zon
+++ b/transfer-lamports/zig/build.zig.zon
@@ -16,8 +16,8 @@
     // internet connectivity.
     .dependencies = .{
         .@"solana-program-sdk" = .{
-            .url = "https://github.com/joncinque/solana-program-sdk-zig/archive/refs/tags/v0.14.0.tar.gz",
-            .hash = "1220bdfa4ea1ab6330959ce4bc40feb5b39a7f98923a266a94b69e27fd20c3526786",
+            .url = "https://github.com/joncinque/solana-program-sdk-zig/archive/refs/tags/v0.15.1.tar.gz",
+            .hash = "12203631b9eba91c479991ec8f0525f181addb5879bbb96e256427f802c2ca67e108",
         },
     },
     .paths = .{


### PR DESCRIPTION
#### Problem

Version 0.15.1 of the Zig SDK optimizes the program entrypoint, but the transfer-lamports zig program is still on an older version.

#### Summary of changes

Update the SDK to 0.15.1 and update the CU usage number.